### PR TITLE
Added sleep and jitter to throttle subsequent request attempts

### DIFF
--- a/core/handlers/enumerator.py
+++ b/core/handlers/enumerator.py
@@ -75,6 +75,13 @@ class Enumerator:
 
     """ Template for HTTP Request """
     def _send_request(self, request, url, auth=None, json=None, data=None, allow_redirects=False, headers=Config.headers):
+        if self.args.sleep > 0:
+            sleep = self.args.sleep
+            if self.args.jitter > 0:
+                sleep = sleep + int(sleep * float(random.randint(1, self.args.jitter) / 100.0))
+            if self.args.debug: print(f"\n[DEBUG]\t\t\tSleeping for {sleep} seconds before sending request...")
+            time.sleep(sleep)
+
         return request(  # Send HTTP request
             url,
             auth=auth,

--- a/core/handlers/sprayer.py
+++ b/core/handlers/sprayer.py
@@ -8,6 +8,7 @@
 
 import re
 import time
+import random
 import urllib3
 import asyncio
 import requests
@@ -72,6 +73,13 @@ class Sprayer:
 
     """ Template for HTTP Request """
     def _send_request(self, request, url, auth=None, data=None, headers=Config.headers):
+        if self.args.sleep > 0:
+            sleep = self.args.sleep
+            if self.args.jitter > 0:
+                sleep = sleep + int(sleep * float(random.randint(1, self.args.jitter) / 100.0))
+            if self.args.debug: print(f"\n[DEBUG]\tSleeping for {sleep} seconds before sending request...")
+            time.sleep(sleep)
+
         return request(  # Send HTTP request
             url,
             auth=auth,

--- a/core/handlers/validator.py
+++ b/core/handlers/validator.py
@@ -2,6 +2,8 @@
 
 # This only sends a single request so we can leave it using the requests function and avoid asyncio
 import html
+import random
+import time
 import requests
 import xml.etree.ElementTree as ET
 from core.utils.colors import text_colors
@@ -24,6 +26,13 @@ class Validator:
 
 
     def _send_request(self, url):
+        if self.args.sleep > 0:
+            sleep = self.args.sleep
+            if self.args.jitter > 0:
+                sleep = sleep + int(sleep * float(random.randint(1, self.args.jitter) / 100.0))
+            if self.args.debug: print(f"\n[DEBUG]\tSleeping for {sleep} seconds before sending request...")
+            time.sleep(sleep)
+
         return requests.get(  # Send HTTP request to validate domain
             url,
             headers=Config.headers,

--- a/o365spray.py
+++ b/o365spray.py
@@ -144,6 +144,22 @@ if __name__ == "__main__":
         default=10
     )
 
+    parser.add_argument(
+        '-s',
+        "--sleep",
+        type=int,
+        help="Throttle subsequent attempts every # seconds, can be randomized by passing the value 'random' (between 1sec and 20 mins) - default is 0",
+        default=0
+    )
+
+    parser.add_argument(
+        '-j',
+        "--jitter",
+        type=int,
+        help="Jitter among subsequent tries. Jitter extends sleep period by percanted given (0-100). Default: no jitter.",
+        default=0
+    )
+
     # HTTP configurations
     parser.add_argument(
         "--timeout",


### PR DESCRIPTION
In order to cool down between subsequent validation/enumeration/brute-force attempts - I've added `--sleep` and `--jitter` options that introduce variant sleep.

Cheers!
Mariusz.