### PR TITLE
Added some init files in folders

### DIFF
--- a/o365spray/__init__.py
+++ b/o365spray/__init__.py
@@ -4,3 +4,4 @@ _V_MAJ = 3
 _V_MIN = 0
 _V_MNT = 4
 __version__ = f"{_V_MAJ}.{_V_MIN}.{_V_MNT}"
+__all__ = ['core']

--- a/o365spray/core/__init__.py
+++ b/o365spray/core/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ['handlers','utils']

--- a/o365spray/core/handlers/__init__.py
+++ b/o365spray/core/handlers/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ['enumerator','sprayer','validator']


### PR DESCRIPTION
This seems to be a requirement when working with setup and setuptools.
Fixes issue:

 `ModuleNotFoundError: No module named 'o365spray.core'`