### PR TITLE
fix: only strip output dir from right side

### DIFF
--- a/o365spray/__main__.py
+++ b/o365spray/__main__.py
@@ -283,7 +283,7 @@ def main():
 
     # If an output directory provided, get or create it
     if args.output:
-        output_directory = args.output.strip("/")
+        output_directory = args.output.rstrip("/")
         Path(output_directory).mkdir(parents=True, exist_ok=True)
 
     # If no output provided, default to the current working directory


### PR DESCRIPTION
Without this fix, the output will always be in the current directory even if we are giving an absolute directory.